### PR TITLE
compatibility with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "pure-swipe",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A 0.7k script that adds swipe events to the DOM for touch enabled devices",
-  "main": "dev-server.js",
+  "main": "src/pure-swipe.js",
   "scripts": {
     "start": "node server/dev-server.js",
     "build": "node_modules/gulp/bin/gulp.js build",

--- a/src/pure-swipe.js
+++ b/src/pure-swipe.js
@@ -106,4 +106,4 @@
         yDiff = yDown - yUp;
     }
 
-}(this, document));
+}(window, document));


### PR DESCRIPTION
(Fixes #1)

Now it's possible to use this module with webpack, by importing it directly:

```
import "pure-swipe";
```

or

```
require('pure-swipe')
```