### PR TITLE
Add TypeScript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.9",
   "description": "A 1k script that adds swipe events to the DOM for touch enabled devices",
   "main": "src/swiped-events.js",
+  "types": "src/swiped-events.d.ts",
   "scripts": {
     "start": "node server/dev-server.js",
     "build": "node_modules/gulp/bin/gulp.js build",

--- a/src/swiped-events.d.ts
+++ b/src/swiped-events.d.ts
@@ -6,11 +6,11 @@ export type SwipedEventTouchType = "stylus" | "direct";
 /**
  * Event data for a "swiped" event
  */
-export type SwipedEventDetail = {
+export type SwipedEventDetail<D extends SwipedEventDirection> = {
     /**
      * Swipe direction (up, down, left, right)
      */
-    dir: SwipedEventDirection,
+    dir: D,
     /**
      * Touch type (stylus, direct)
      *
@@ -43,12 +43,11 @@ export type SwipedEventDetail = {
 
 export type SwipedEventType = "swiped" | `swiped-${SwipedEventDirection}`;
 
-export type SwipedEvent = Event & { detail: SwipedEventDetail, type: SwipedEventType };
-
-export type SwipedLeftEvent = Event & { detail: SwipedEventDetail, type: "swiped-left" };
-export type SwipedRightEvent = Event & { detail: SwipedEventDetail, type: "swiped-right" };
-export type SwipedUpEvent = Event & { detail: SwipedEventDetail, type: "swiped-up" };
-export type SwipedDownEvent = Event & { detail: SwipedEventDetail, type: "swiped-down" };
+export type SwipedEvent = Event & { detail: SwipedEventDetail<SwipedEventDirection>, type: SwipedEventType };
+export type SwipedLeftEvent = Event & { detail: SwipedEventDetail<"left">, type: "swiped-left" };
+export type SwipedRightEvent = Event & { detail: SwipedEventDetail<"right">, type: "swiped-right" };
+export type SwipedUpEvent = Event & { detail: SwipedEventDetail<"up">, type: "swiped-up" };
+export type SwipedDownEvent = Event & { detail: SwipedEventDetail<"down">, type: "swiped-down" };
 
 export type SwipedEventMap = {
     "swiped": SwipedEvent,

--- a/src/swiped-events.d.ts
+++ b/src/swiped-events.d.ts
@@ -6,7 +6,7 @@ export type SwipedEventTouchType = "stylus" | "direct";
 /**
  * Event data for a "swiped" event
  */
-export type SwipedEventDetail<D extends SwipedEventDirection> = {
+export type SwipedEventDetail<D extends SwipedEventDirection = SwipedEventDirection> = {
     /**
      * Swipe direction (up, down, left, right)
      */
@@ -43,11 +43,11 @@ export type SwipedEventDetail<D extends SwipedEventDirection> = {
 
 export type SwipedEventType = "swiped" | `swiped-${SwipedEventDirection}`;
 
-export type SwipedEvent = Event & { detail: SwipedEventDetail<SwipedEventDirection>, type: SwipedEventType };
-export type SwipedLeftEvent = Event & { detail: SwipedEventDetail<"left">, type: "swiped-left" };
-export type SwipedRightEvent = Event & { detail: SwipedEventDetail<"right">, type: "swiped-right" };
-export type SwipedUpEvent = Event & { detail: SwipedEventDetail<"up">, type: "swiped-up" };
-export type SwipedDownEvent = Event & { detail: SwipedEventDetail<"down">, type: "swiped-down" };
+export type SwipedEvent = CustomEvent<SwipedEventDetail> & { type: SwipedEventType };
+export type SwipedLeftEvent = CustomEvent<SwipedEventDetail<"left">> & { type: "swiped-left" };
+export type SwipedRightEvent = CustomEvent<SwipedEventDetail<"right">> & { type: "swiped-right" };
+export type SwipedUpEvent = CustomEvent<SwipedEventDetail<"up">> & { type: "swiped-up" };
+export type SwipedDownEvent = CustomEvent<SwipedEventDetail<"down">> & { type: "swiped-down" };
 
 export type SwipedEventMap = {
     "swiped": SwipedEvent,

--- a/src/swiped-events.d.ts
+++ b/src/swiped-events.d.ts
@@ -1,0 +1,58 @@
+
+export type SwipedEventDirection = "up" | "down" | "left" | "right";
+
+export type SwipedEventTouchType = "stylus" | "direct";
+
+/**
+ * Event data for a "swiped" event
+ */
+export type SwipedEventDetail = {
+    /**
+     * Swipe direction (up, down, left, right)
+     */
+    dir: SwipedEventDirection,
+    /**
+     * Touch type (stylus, direct)
+     *
+     * stylus = apple pencil
+     *
+     * direct = finger
+     */
+    touchType: SwipedEventTouchType,
+    /**
+     * X coordinates of swipe start
+     */
+    xStart: number,
+    /**
+     * X coordinates of swipe end
+     */
+    xEnd: number,
+    /**
+     * Y coordinates of swipe start
+     */
+    yStart: number,
+    /**
+     * Y coordinates of swipe end
+     */
+    yEnd: number,
+    /**
+     * Number of fingers used
+     */
+    fingers: number
+};
+
+export type SwipedEvent = Event & { detail: SwipedEventDetail };
+
+export type SwipedEventType = "swiped" | `swiped-${SwipedEventDirection}`;
+
+
+declare global {
+    interface HTMLElement {
+        addEventListener(type: "swiped", callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: SwipedEventType, callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
+    }
+    interface Window {
+        addEventListener(type: "swiped", callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: SwipedEventType, callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
+    }
+}

--- a/src/swiped-events.d.ts
+++ b/src/swiped-events.d.ts
@@ -41,9 +41,9 @@ export type SwipedEventDetail = {
     fingers: number
 };
 
-export type SwipedEvent = Event & { detail: SwipedEventDetail };
-
 export type SwipedEventType = "swiped" | `swiped-${SwipedEventDirection}`;
+
+export type SwipedEvent = Event & { detail: SwipedEventDetail, type: SwipedEventType };
 
 
 declare global {

--- a/src/swiped-events.d.ts
+++ b/src/swiped-events.d.ts
@@ -45,14 +45,27 @@ export type SwipedEventType = "swiped" | `swiped-${SwipedEventDirection}`;
 
 export type SwipedEvent = Event & { detail: SwipedEventDetail, type: SwipedEventType };
 
+export type SwipedLeftEvent = Event & { detail: SwipedEventDetail, type: "swiped-left" };
+export type SwipedRightEvent = Event & { detail: SwipedEventDetail, type: "swiped-right" };
+export type SwipedUpEvent = Event & { detail: SwipedEventDetail, type: "swiped-up" };
+export type SwipedDownEvent = Event & { detail: SwipedEventDetail, type: "swiped-down" };
+
+export type SwipedEventMap = {
+    "swiped": SwipedEvent,
+    "swiped-left": SwipedLeftEvent,
+    "swiped-right": SwipedRightEvent,
+    "swiped-up": SwipedUpEvent,
+    "swiped-down": SwipedDownEvent
+};
+
 
 declare global {
     interface HTMLElement {
         addEventListener(type: "swiped", callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: SwipedEventType, callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<T extends keyof SwipedEventMap>(type: T, callback: ((v: SwipedEventMap[T]) => void) | null, options?: boolean | AddEventListenerOptions): void;
     }
     interface Window {
         addEventListener(type: "swiped", callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: SwipedEventType, callback: ((v: SwipedEvent) => void) | null, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<T extends keyof SwipedEventMap>(type: T, callback: ((v: SwipedEventMap[T]) => void) | null, options?: boolean | AddEventListenerOptions): void;
     }
 }


### PR DESCRIPTION
Adds declarations for TypeScript. This will, for instance, allow for this:
```ts
document.body.addEventListener("swiped", (e: SwipedEvent) => {
     console.log("Swiped " + e.detail.dir); // Swiped left | Swiped up | Swiped down | Swiped right
});
```

Instead of this:
```ts
document.body.addEventListener("swiped", (e: Event) => {
     const dir: string = (e as unknown as { detail: { dir: string } }).detail.dir;
     console.log("Swiped " + dir); // Swiped (undeclared)
});
```

This also allows IDEs like WebStorm to make more informed inspections & suggestions. This doesn't change the distribution size, just the source size. As it stands, people using TypeScript along with this package must essentially write this code themselves (perhaps less cleanly).